### PR TITLE
Accept arrays for postfix maps, when order is important

### DIFF
--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -14,6 +14,7 @@
 #
 # [*maps*]
 #   Sets the value of content parameter for the postfix lookup table
+#   Possible values are hashes, arrays, or arrays of arrays (see Usage).
 #   Note: This option is alternative to the source one
 #
 # [*path*]
@@ -38,6 +39,15 @@
 #     'user1@virtual-alias.example.org' => 'address1',
 #     'user2@virtual-alias.example.org' => ['address2', 'address3'],
 #   }
+# }
+#
+# Use arrays when order is important
+#
+# postfix::map { 'access':
+#   maps => [
+#     ['user1@example.org', 'OK'],
+#     ['example.org', 'REJECT',
+#   ]
 # }
 #
 define postfix::map(

--- a/templates/map.erb
+++ b/templates/map.erb
@@ -1,3 +1,11 @@
+<% if maps.is_a? Hash -%>
 <% maps.sort_by {|k, v| k}.each do |key, value| -%>
 <%= key %> <%= [value].flatten.join(', ') %>
+<% end -%>
+<% elsif @maps.is_a? Array -%>
+<% maps.each do |x| -%>
+<%= [x].flatten.join(' ') %>
+<% end -%>
+<% else -%>
+<%= [maps].to_s %>
 <% end -%>


### PR DESCRIPTION
Ruby 1.8.x doesn't preserve hash orders, so we accept arrays also.

(Backward-compatibility is preserved)
