### PR TITLE
Postalias and Postmap commands are not executed if the .db files already exists.

### DIFF
--- a/manifests/aliases.pp
+++ b/manifests/aliases.pp
@@ -61,7 +61,6 @@ class postfix::aliases(
       owner   => $postfix::config_file_owner,
       group   => $postfix::config_file_group,
       require => Package['postfix'],
-      notify  => Exec["postalias"],
       source  => $manage_file_source,
       content => $manage_file_content,
       replace => $postfix::manage_file_replace,
@@ -71,7 +70,8 @@ class postfix::aliases(
     "postalias":
       command => "/usr/sbin/postalias '${postfix::aliases_file}'",
       require => Package['postfix'],
-      creates => "${postfix::aliases_file}.db";
+      subscribe => File['postfix::aliases'],
+      refreshonly => true;
   }
 }
 

--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -80,7 +80,6 @@ define postfix::map(
       owner   => $postfix::config_file_owner,
       group   => $postfix::config_file_group,
       require => Package['postfix'],
-      notify  => Exec["postmap-${name}"],
       source  => $manage_file_source,
       content => $manage_file_content,
       replace => $postfix::manage_file_replace,
@@ -90,7 +89,8 @@ define postfix::map(
     "postmap-${name}":
       command => "/usr/sbin/postmap ${path}",
       require => Package['postfix'],
-      creates => "${path}.db";
+      subscribe => File["postmap-${name}"],
+      refreshonly => true;
   }
 }
 


### PR DESCRIPTION
Updating the manifests trigger the Exec but the command is not executed. According with the documentation, the `creates` param is the problem: "A file that this command creates. If this parameter is provided, then the command will only be run if the specified file does not exist."

I switched to `subscribe` and `refreshonly` instead.

Ref: http://docs.puppetlabs.com/references/2.7.0/type.html#exec 
