### PR TITLE
Fixing wrong file referenced on `subscribe` parameter.

### DIFF
--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -89,7 +89,7 @@ define postfix::map(
     "postmap-${name}":
       command => "/usr/sbin/postmap ${path}",
       require => Package['postfix'],
-      subscribe => File["postmap-${name}"],
+      subscribe => File["postfix::map_${name}"],
       refreshonly => true;
   }
 }


### PR DESCRIPTION
My mistake. The `subscribe` parameter was referencing `"postmap-${name}"` instead of `"postfix::map_${name}"`.
