### PR TITLE
Moved my_class import higher so variables can be used in templates

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -272,6 +272,12 @@ class postfix (
   $bool_debug=any2bool($debug)
   $bool_audit_only=any2bool($audit_only)
 
+  ### Include custom class if $my_class is set
+  if $postfix::my_class {
+    include $postfix::my_class
+  }
+
+
   ### Definition of some variables used in the module
   $manage_package = $postfix::bool_absent ? {
     true  => 'absent',
@@ -391,12 +397,6 @@ class postfix (
       replace => $postfix::manage_file_replace,
       audit   => $postfix::manage_audit,
     }
-  }
-
-
-  ### Include custom class if $my_class is set
-  if $postfix::my_class {
-    include $postfix::my_class
   }
 
 


### PR DESCRIPTION
Needed to add a variable to the main.cf template.  This seemed to be the simplest way.
